### PR TITLE
If there is a timeout, just keep waiting.

### DIFF
--- a/lib/etcd/client.rb
+++ b/lib/etcd/client.rb
@@ -115,12 +115,17 @@ module Etcd
     # * key   - key to be watched
     # * index - etcd server index of specified key (optional)
     def watch(key, index=nil)
-      response = if index.nil?
-                    api_execute(watch_endpoint + key, :get)
-                  else
-                    api_execute(watch_endpoint + key, :post, {'index' => index})
-                  end
-      json2obj(response)
+      loop do
+        begin
+          response = if index.nil?
+                        api_execute(watch_endpoint + key, :get)
+                      else
+                        api_execute(watch_endpoint + key, :post, {'index' => index})
+                      end
+          return json2obj(response)
+        rescue Timeout::Error
+        end
+      end
     end
 
     # This method sends api request to etcd server.


### PR DESCRIPTION
Simple change to support watch without timing out. Perhaps watch itself needs an explicit timeout? It would think that would be distinct from the normal one though, and should definitely support "unlimited".
