### PR TITLE
support individual call wise http read timeouts

### DIFF
--- a/spec/functional/read_only_client_spec.rb
+++ b/spec/functional/read_only_client_spec.rb
@@ -18,7 +18,7 @@ shared_examples "read only client" do
     key = random_key
     value = uuid.generate
     index = client.set(key, value).index
-    expect(read_only_client.watch(key, index).value).to eq(value)
+    expect(read_only_client.watch(key, index: index).value).to eq(value)
   end
 end
 

--- a/spec/functional/watch_spec.rb
+++ b/spec/functional/watch_spec.rb
@@ -7,8 +7,8 @@ shared_examples "watch" do
     index1 = client.set(key, value1).index
     index2 = client.set(key, value2).index
 
-    expect(client.watch(key, index1).value).to eq(value1)
-    expect(client.watch(key, index2).value).to eq(value2)
+    expect(client.watch(key, index: index1).value).to eq(value1)
+    expect(client.watch(key, index: index2).value).to eq(value2)
   end
 
   it "with index, waits and return when the key is updated" do

--- a/spec/unit/etcd/client_spec.rb
+++ b/spec/unit/etcd/client_spec.rb
@@ -33,28 +33,28 @@ describe Etcd::Client do
 
   describe "#set" do
     it "set('/foo', 1) should invoke /v1/keys/foo POST http request" do
-      client.should_receive(:api_execute).with('/v1/keys/foo', :post, {'value'=>1}).and_return('{"value":1}')
+      client.should_receive(:api_execute).with('/v1/keys/foo', :post, params: {'value'=>1}).and_return('{"value":1}')
       expect(client.set('/foo', 1).value).to eq(1)
     end
     it "set('/foo', 1, 4) should invoke /v1/keys/foo POST http request and set the ttl to 4" do
-      client.should_receive(:api_execute).with('/v1/keys/foo', :post, {'value'=>1, 'ttl'=>4}).and_return('{"value":1}')
+      client.should_receive(:api_execute).with('/v1/keys/foo', :post, params: {'value'=>1, 'ttl'=>4}).and_return('{"value":1}')
       expect(client.set('/foo', 1, 4).value).to eq(1)
     end
   end
 
   describe "#test_and_set" do
     it "test_and_set('/foo', 1, 4) should invoke /v1/keys/foo POST http request" do
-      client.should_receive(:api_execute).with('/v1/keys/foo', :post, {'value'=>1, 'prevValue'=>4}).and_return('{"value":1}')
+      client.should_receive(:api_execute).with('/v1/keys/foo', :post, params: {'value'=>1, 'prevValue'=>4}).and_return('{"value":1}')
       expect(client.test_and_set('/foo', 1, 4).value).to eq(1)
     end
     it "test_and_set('/foo', 1, 4, 10) should invoke /v1/keys/foo POST http request and set the ttl to 10" do
-      client.should_receive(:api_execute).with('/v1/keys/foo', :post, {'value'=>1, 'prevValue'=>4, 'ttl'=>10}).and_return('{"value":1}')
+      client.should_receive(:api_execute).with('/v1/keys/foo', :post, params: {'value'=>1, 'prevValue'=>4, 'ttl'=>10}).and_return('{"value":1}')
       expect(client.test_and_set('/foo', 1, 4, 10).value).to eq(1)
     end
   end
 
   it "#watch('/foo') should make /v1/watch/foo GET http request" do
-    client.should_receive(:api_execute).with('/v1/watch/foo', :get).and_return('{"value":1}')
+    client.should_receive(:api_execute).with('/v1/watch/foo', :get, {timeout: 60}).and_return('{"value":1}')
     expect(client.watch('/foo').value).to eq(1)
   end
 


### PR DESCRIPTION
Support http read time out on per api call basis.
https://github.com/ranjib/etcd-ruby/pull/7
