### PR TITLE
Expose http header based metadata via api

### DIFF
--- a/lib/etcd/lock.rb
+++ b/lib/etcd/lock.rb
@@ -2,13 +2,12 @@ require 'uuid'
 
 module Etcd
   class Lock
+
     class AcqusitionFailure < StandardError; end
     class ReleaseFailure < StandardError; end
 
-
     attr_reader :lock_id, :key, :value, :client
     attr_reader :retries, :retry_interval, :attempts
-
 
     def initialize(opts={})
       @client = opts[:client]

--- a/lib/etcd/node.rb
+++ b/lib/etcd/node.rb
@@ -2,6 +2,8 @@
 module Etcd
   class Node
 
+    include Comparable
+
     attr_reader :created_index, :modified_index, :expiration, :ttl, :key, :value
     alias :createdIndex :created_index
     alias :modifiedIndex :modified_index
@@ -16,11 +18,15 @@ module Etcd
       @expiration = opts['expiration']
       @dir = opts['dir']
 
-      if opts['dir']
+      if opts['dir'] and (!!opts['nodes'])
         opts['nodes'].each do |data|
           children << Node.new(data)
         end
       end
+    end
+
+    def <=>(other)
+      key <=> other.key
     end
 
     def children

--- a/lib/etcd/response.rb
+++ b/lib/etcd/response.rb
@@ -7,17 +7,25 @@ module Etcd
 
     extend Forwardable
 
-    attr_reader :action, :node
+    attr_reader :action, :node, :etcd_index, :raft_index, :raft_term
 
-    def_delegators :@node, :key, :value
+    def_delegators :@node, :key, :value, :directory?, :children
 
-    def initialize(opts)
+    def initialize(opts, headers={})
       @action = opts['action']
       @node = Node.new(opts['node'])
+      @etcd_index = headers[:etcd_index]
+      @raft_index = headers[:raft_index]
+      @raft_term = headers[:raft_term]
     end
 
-    def self.from_json(json)
-      Response.new(JSON.parse(json))
+    def self.from_http_response(response)
+      data = JSON.parse(response.body)
+      headers = Hash.new
+      headers[:etcd_index] = response['X-Etcd-Index'].to_i
+      headers[:raft_index] = response['X-Raft-Index'].to_i
+      headers[:raft_term] = response['X-Raft-Term'].to_i
+      response = Response.new(data, headers)
     end
   end
 end

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -9,11 +9,31 @@ describe "Functional Test Suite" do
     expect(client.get(key).value).to eq(value)
   end
 
-  it "#leader" do
-    expect(etcd_servers).to include(client.leader)
+  it "should return the leade's address" do
+    expect(client.leader).to_not be_nil
   end
 
   it "#machines" do
     expect(client.machines).to include('http://127.0.0.1:4001')
+  end
+
+  context "#http header based metadata" do
+    before(:all) do
+      key = random_key
+      value = uuid.generate
+      @response = client.set(key,value)
+    end
+
+    it "#etcd_index" do
+      expect(@response.etcd_index).to_not be_nil
+    end
+
+    it "#raft_index" do
+      expect(@response.raft_index).to_not be_nil
+    end
+
+    it "#raft_term" do
+      expect(@response.raft_term).to_not be_nil
+    end
   end
 end

--- a/spec/functional/directory_spec.rb
+++ b/spec/functional/directory_spec.rb
@@ -1,0 +1,12 @@
+require 'functional_spec_helpers'
+
+describe "Etcd directory node" do
+  it "should create a directory with parent key when nested keys are set" do
+    parent = random_key
+    child = random_key
+    value = uuid.generate
+    client.set(parent+child, value)
+    expect(client.get(parent+child)).to_not be_directory
+    expect(client.get(parent)).to be_directory
+  end
+end

--- a/spec/functional/readme_spec.rb
+++ b/spec/functional/readme_spec.rb
@@ -1,0 +1,305 @@
+require 'functional_spec_helpers'
+
+describe "Etcd specs for the main etcd README examples" do
+
+  shared_examples "response with valid node data" do |action|
+    if action == :delete
+      it "should not have value" do
+        expect(@response.node.value).to be_nil
+      end
+    else
+      it "should set the value correctly" do
+        expect(@response.node.value).to eq('PinkFloyd')
+      end
+    end
+    if action == :create
+      it "should set the parent key correctly" do
+        expect(@response.node.key).to match /^\/queue\/+/
+      end
+    else
+      it "should set the key properly" do
+        expect(@response.node.key).to eq('/message')
+      end
+    end
+
+    it "modified index should be a positive integer" do
+      expect(@response.node.created_index).to be > 0
+    end
+
+    it "created index should be a positive integer" do
+      expect(@response.node.modified_index).to be > 0
+    end
+  end
+
+  shared_examples "response with valid http headers" do
+
+    it "should have a positive etcd index (comes from http header)" do
+      expect(@response.etcd_index).to be > 0
+    end
+
+    it "should have a positive raft index (comes from http header)" do
+      expect(@response.raft_index).to be > 0
+    end
+
+    it "should have a positive raft term (comes from http header)" do
+      expect(@response.raft_term).to be >= 0
+    end
+  end
+
+  context "set a key named '/message'" do
+
+    before(:all) do
+     @response = client.set('/message', 'PinkFloyd')
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data"
+
+    it "should set the return action to SET" do
+      expect(@response.action).to eq("set")
+    end
+  end
+
+  context "get a key named '/message'" do
+
+    before(:all) do
+      client.set('/message', 'PinkFloyd')
+      @response = client.get('/message')
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data"
+
+    it "should set the return action to GET" do
+      expect(@response.action).to eq("get")
+    end
+  end
+
+  context "change the value of a key named '/message'" do
+
+    before(:all) do
+      client.set('/message', 'World')
+      @response = client.set('/message','PinkFloyd')
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data"
+
+    it "should set the return action to SET" do
+      expect(@response.action).to eq("set")
+    end
+  end
+
+  context "delete a key named '/message'" do
+
+    before(:all) do
+      client.set('/message', 'World')
+      client.set('/message','PinkFloyd')
+      @response = client.delete('/message')
+    end
+
+    it "should set the return action to SET" do
+      expect(@response.action).to eq("delete")
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data", :delete
+  end
+
+  context "using ttl a key named '/message'" do
+
+    before(:all) do
+      client.set('/message', 'World')
+      @set_time = Time.now
+      @response = client.set('/message','PinkFloyd', 5)
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data"
+
+    it "should set the return action to SET" do
+      expect(@response.action).to eq("set")
+    end
+
+    it "should have valid expiration time" do
+      expect(@response.node.expiration).to_not be_nil
+    end
+
+    it "should have ttl available from the node" do
+      expect(@response.node.ttl).to eq(5)
+    end
+
+    it "should throw exception after the expiration time" do
+      sleep 8
+      expect do
+        client.get('/message')
+      end.to raise_error
+    end
+
+  end
+
+  context "waiting for a change against a key named '/message'" do
+
+    before(:all) do
+      client.set('/message', 'foo')
+      thr = Thread.new do
+        @response = client.watch('/message')
+      end
+      client.set('/message', 'PinkFloyd')
+      thr.join
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data"
+
+    it "should set the return action to SET" do
+      expect(@response.action).to eq("set")
+    end
+
+    it "should get the exact value by specifying a waitIndex" do
+      client.set('/message', 'someshit')
+      w_response = client.watch('/message', index: @response.node.modified_index)
+      expect(w_response.node.value).to eq('PinkFloyd')
+    end
+  end
+
+  context "atomic in-order keys" do
+
+    before(:all) do
+      @response = client.atomic_create('/queue', 'PinkFloyd')
+    end
+
+    it_should_behave_like "response with valid http headers"
+    it_should_behave_like "response with valid node data", :create
+
+    it "should set the return action to create" do
+      expect(@response.action).to eq("create")
+    end
+
+    it "should have the child key as a positive integer" do
+      expect(@response.key.split('/').last.to_i).to be > 0
+    end
+
+    it "should have the child keys as monotonically increasing" do
+      first_response = client.atomic_create('/queue', 'The Jimi Hendrix Experience')
+      second_response = client.atomic_create('/queue', 'The Doors')
+      first_key = first_response.key.split('/').last.to_i
+      second_key = second_response.key.split('/').last.to_i
+      expect(first_key).to be < second_key
+    end
+
+    it "should enlist all children in sorted manner" do
+      responses = []
+      10.times do |n|
+        responses << client.atomic_create('/queue', "Deep Purple - Track #{n}")
+      end
+      directory = client.get('/queue', sorted: true)
+      past_index = directory.children.index(responses.first.node)
+      9.times do |n|
+        current_index = directory.children.index(responses[n+1].node)
+        expect(current_index).to be > past_index
+        past_index = current_index
+      end
+    end
+  end
+
+  context "directory with ttl" do
+
+    before(:all) do
+      @response = client.set('/directory', dir: true, ttl: 4)
+    end
+
+    it "should create a directory" do
+      expect(client.get('/directory')).to be_directory
+    end
+
+    it "should have valid expiration time" do
+      expect(client.get('/directory').node.expiration).to_not be_nil
+    end
+
+    it "should have pre-designated ttl" do
+      expect(client.get('/directory').node.ttl).to eq(4)
+    end
+
+    it "will throw error if updated without setting prevExist" do
+      expect do
+        client.set('/directory', dir:true, ttl:5)
+      end.to raise_error
+    end
+
+    it "can be updated by setting  prevExist to true" do
+      client.set('/directory', prevExist: true, dir:true, ttl:5)
+      expect(client.get('/directory').node.ttl).to eq(5)
+    end
+
+    it "watchers should get expriy notification" do
+      client.set('/directory/a', 'Test')
+      client.set('/directory', prevExist: true, dir:true, ttl:2)
+      response = client.watch('/directory/a', consistent: true, timeout: 3)
+      expect(response.action).to eq('expire')
+    end
+    it "should be expired after ttl" do
+      sleep 5
+      expect do
+        client.get('/directory')
+      end.to raise_error
+    end
+  end
+
+  context "atomic compare and swap" do
+
+    it "should  raise error if prevExist is passed a false" do
+      client.set('/foo', 'one')
+      expect do
+        client.set('/foo','three', prevExist: false)
+      end.to raise_error
+    end
+
+    it "should raise error is prevValue is wrong" do
+      client.set('/foo', 'one')
+      expect do
+        client.set('/foo','three', prevValue: 'two')
+      end.to raise_error
+    end
+
+    it "should allow setting the value when prevValue is right" do
+      client.set('/foo', 'one')
+      expect(client.set('/foo','three', prevValue: 'one').value).to eq('three')
+    end
+  end
+  context "directory manipulation" do
+    it "should allow creating directory" do
+      expect(client.set('/dir',dir:true)).to be_directory
+    end
+
+    it "should allow listing directory" do
+      client.set('/foo_dir/foo','bar')
+      expect(client.get('/').children.map(&:key)).to include('/foo_dir')
+    end
+
+    it "should allow recursive directory listing" do
+      response = client.get('/', recursive: true)
+      expect(response.children.find{|n|n.key=='/foo_dir'}.children).to_not be_empty
+    end
+
+    it "should be able to delete empty directory without the recusrive flag" do
+      expect(client.delete('/dir', dir: true).action).to eq('delete')
+    end
+
+    it "should be able to delete directory with children with the recusrive flag" do
+      expect(client.delete('/foo_dir', recursive: true).action).to eq('delete')
+    end
+  end
+
+  context "hidden nodes" do
+
+    before(:all) do
+      client.set('/_message', 'Hello Hidden World')
+      client.set('/message', 'Hello World')
+    end
+
+    it "should not be visible in directory listing" do
+      expect(client.get('/').children.map(&:key)).to_not include('_message')
+    end
+  end
+end

--- a/spec/unit/etcd/client_spec.rb
+++ b/spec/unit/etcd/client_spec.rb
@@ -3,6 +3,14 @@ require 'unit/etcd/mixins/helpers_spec'
 
 describe Etcd::Client do
 
+  let(:mock_json_data) do
+    double(Net::HTTPSuccess, body: '{"node":{"value":1}}',:[] => nil)
+  end
+
+  let(:mock_text_data) do
+    double(Net::HTTPSuccess, body: 'foobar', :[] => nil)
+  end
+
   let(:client) do
     Etcd::Client.new
   end
@@ -25,49 +33,49 @@ describe Etcd::Client do
   end
 
   it "#machines should make /machines GET http request" do
-    client.should_receive(:api_execute).with('/v2/machines', :get).and_return('foobar')
+    client.should_receive(:api_execute).with('/v2/machines', :get).and_return(mock_text_data)
     expect(client.machines).to eq(['foobar'])
   end
 
   it "#leader should make /leader GET http request" do
-    client.should_receive(:api_execute).with('/v2/leader', :get).and_return('foobar')
+    client.should_receive(:api_execute).with('/v2/leader', :get).and_return(mock_text_data)
     expect(client.leader).to eq('foobar')
   end
 
   it "#get('/foo') should make /v2/keys/foo GET http request" do
-    client.should_receive(:api_execute).with('/v2/keys/foo', :get, {:params=>{}}).and_return('{"node":{"value":1}}')
+    client.should_receive(:api_execute).with('/v2/keys/foo', :get, {:params=>{}}).and_return(mock_json_data)
     expect(client.get('/foo').value).to eq(1)
   end
 
   describe "#set" do
     it "set('/foo', 1) should invoke /v2/keys/foo PUT http request" do
-      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1}).and_return('{"node":{"value":1}}')
+      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1}).and_return(mock_json_data)
       expect(client.set('/foo', 1).value).to eq(1)
     end
     it "set('/foo', 1, 4) should invoke /v2/keys/foo PUT http request and set the ttl to 4" do
-      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1, 'ttl'=>4}).and_return('{"node":{"value":1}}')
+      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1, 'ttl'=>4}).and_return(mock_json_data)
       expect(client.set('/foo', 1, 4).value).to eq(1)
     end
   end
 
   describe "#test_and_set" do
     it "test_and_set('/foo', 1, 4) should invoke /v2/keys/foo PUT http request" do
-      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1, 'prevValue'=>4}).and_return('{"node":{"value":1}}')
+      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1, 'prevValue'=>4}).and_return(mock_json_data)
       expect(client.test_and_set('/foo', 1, 4).node.value).to eq(1)
     end
     it "test_and_set('/foo', 1, 4, 10) should invoke /v2/keys/foo PUT http request and set the ttl to 10" do
-      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1, 'prevValue'=>4, 'ttl'=>10}).and_return('{"node":{"value":1}}')
+      client.should_receive(:api_execute).with('/v2/keys/foo', :put, params: {'value'=>1, 'prevValue'=>4, 'ttl'=>10}).and_return(mock_json_data)
       expect(client.test_and_set('/foo', 1, 4, 10).node.value).to eq(1)
     end
   end
 
   it "#watch('/foo') should make /v2/watch/foo GET http request" do
-    client.should_receive(:api_execute).with('/v2/keys/foo', :get, {:timeout=>60, :params=>{:wait=>true}}).and_return('{"node":{"value":1}}')
+    client.should_receive(:api_execute).with('/v2/keys/foo', :get, {:timeout=>60, :params=>{:wait=>true}}).and_return(mock_json_data)
     expect(client.watch('/foo').node.value).to eq(1)
   end
 
   it "#delete('/foo') should make /v2/keys/foo DELETE http request" do
-    client.should_receive(:api_execute).with('/v2/keys/foo', :delete, {:params=>{}}).and_return('{"node":{}}')
+    client.should_receive(:api_execute).with('/v2/keys/foo', :delete, {:params=>{}}).and_return(mock_json_data)
     client.delete('/foo')
   end
 


### PR DESCRIPTION
- Expose `X-Etcd-Index` , `X-Raft-Index` , `X-Raft-Term` via api
- Write specs against the main Etcd README examples. (It will be nice to have `etcd-ruby`  usage examples same as the main `etcd` README)
- Some code changes on main client class to address `prevIndex`, `prevValue` and `prevExist` based test and set operation.
- Make `Etcd::Node` comparable (need a larger debate on the logic for comparison) 
