### PR TITLE
Parse and produce etcd exceptions

### DIFF
--- a/lib/etcd/client.rb
+++ b/lib/etcd/client.rb
@@ -4,7 +4,7 @@ require 'etcd/log'
 require 'etcd/mixins/helpers'
 require 'etcd/mixins/lockable'
 require 'etcd/response'
-
+require 'etcd/exceptions'
 
 module Etcd
   ##
@@ -13,6 +13,10 @@ module Etcd
   # and Etcd::Client#eternal_watch, they are defined in separate modules and included in this
   # class
   class Client
+
+    HTTP_REDIRECT = ->(r){ r.is_a? Net::HTTPRedirection }
+    HTTP_SUCCESS = ->(r){ r.is_a? Net::HTTPSuccess }
+    HTTP_CLIENT_ERROR = ->(r){ r.is_a? Net::HTTPClientError }
 
     include Etcd::Helpers
     include Etcd::Lockable
@@ -221,12 +225,21 @@ module Etcd
       Log.debug("Invoking: '#{req.class}' against '#{path}")
       res = http.request(req)
       Log.debug("Response code: #{res.code}")
-      if res.is_a?(Net::HTTPSuccess)
+
+      case res
+      when HTTP_SUCCESS
         Log.debug("Http success")
         res
-      elsif redirect?(res.code.to_i) and allow_redirect
-        Log.debug("Http redirect, following")
-        api_execute(res['location'], method, params: params)
+      when HTTP_REDIRECT
+        if allow_redirect
+          Log.debug("Http redirect, following")
+          api_execute(res['location'], method, params: params)
+        else
+          Log.debug("Http redirect not allowed")
+          res.error!
+        end
+      when HTTP_CLIENT_ERROR
+        raise Error.from_http_response(res)
       else
         Log.debug("Http error")
         Log.debug(res.body)

--- a/lib/etcd/exceptions.rb
+++ b/lib/etcd/exceptions.rb
@@ -1,0 +1,72 @@
+require 'json'
+
+module Etcd
+
+  class Error < StandardError
+
+
+    attr_reader :cause, :error_code, :index
+
+    def initialize(opts={})
+      super(opts['message'])
+      @cause = opts['cause']
+      @index = opts['index']
+      @error_code = opts['errorCode']
+    end
+
+    def self.from_http_response(response)
+      opts = JSON.parse(response.body)
+      raise "Unknown error code: #{opts['errorCode']}" unless ERROR_CODE_MAPPING.has_key?(opts['errorCode'])
+      ERROR_CODE_MAPPING[opts['errorCode']].new(opts)
+    end
+
+    def inspect
+      "<#{self.class}: index:#{index}, code:#{error_code}, cause:'#{cause}', message: '#{message}'>"
+    end
+  end
+
+  # command related error
+  class KeyNotFound < Error; end
+  class TestFailed < Error; end
+  class NotFile < Error; end
+  class NoMorePeer < Error; end
+  class NotDir < Error; end
+  class NodeExist < Error; end
+  class KeyIsPreserved < Error; end
+
+  # Post form related error
+  class ValueRequired < Error; end
+  class PrevValueRequired < Error; end
+  class TTLNaN < Error; end
+  class IndexNaN < Error; end
+
+  # Raft related error
+  class RaftInternal < Error; end
+  class LeaderElect < Error; end
+
+  # Etcd related error
+  class WatcherCleared < Error; end
+  class EventIndexCleared < Error; end
+    ERROR_CODE_MAPPING = {
+      # command related error
+      100 => KeyNotFound,
+      101 => TestFailed,
+      102 => NotFile,
+      103 => NoMorePeer,
+      104 => NotDir,
+      105 => NodeExist,
+      106 => KeyIsPreserved,
+      # Post form related error
+      200 => ValueRequired,
+      201 => PrevValueRequired,
+      202 => TTLNaN,
+      203 =>IndexNaN,
+      # Raft related error
+      300 => RaftInternal,
+      301 => LeaderElect,
+      # Etcd related error
+      400 => WatcherCleared,
+      401 => EventIndexCleared
+    }
+
+end

--- a/spec/functional/test_and_set_spec.rb
+++ b/spec/functional/test_and_set_spec.rb
@@ -15,7 +15,7 @@ describe "Etcd test_and_set" do
     key = random_key(2)
     value = uuid.generate
     client.set(key, value)
-    expect{ client.test_and_set(key, 10, 2)}.to raise_error(Net::HTTPServerException)
+    expect{ client.test_and_set(key, 10, 2)}.to raise_error(Etcd::TestFailed)
   end
 
   it "#create should succeed when the key is absent and update should fail" do


### PR DESCRIPTION
Etcd provides a set of [predefined exceptions](https://github.com/coreos/etcd/blob/master/Documentation/errorcode.md), modelling them as individual exception classes will allow consumer scripts to take appropriate measures depending on the classes, without parsing the response body. 
