### PR TITLE
Added missing require for OpenSSL

### DIFF
--- a/lib/etcd/client.rb
+++ b/lib/etcd/client.rb
@@ -8,6 +8,7 @@ require 'etcd/keys'
 require 'etcd/exceptions'
 require 'etcd/mod/lock'
 require 'etcd/mod/leader'
+require 'OpenSSL'
 
 module Etcd
   ##


### PR DESCRIPTION
Here's the problem:

```
% pry
[1] pry(main)> require 'etcd'
=> true
[2] pry(main)> client = Etcd.client
NameError: uninitialized constant Etcd::Client::OpenSSL
from /Users/farcaller/.rvm/gems/ruby-2.1.0/gems/etcd-0.0.6/lib/etcd/client.rb:36:in `initialize'
```
