### PR TITLE
add missing gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ gem 'coco'
 gem 'rubocop'
 gem 'guard'
 gem 'guard-rake'
+gem 'json'
 # uuid gem isn't pulling in systemu
 gem 'systemu'

--- a/etcd.gemspec
+++ b/etcd.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "uuid"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
- need rdoc for dev
- need json for dev and regular usage

In a clean bundle environment on F20, `bundle exec rake -T`
fails unless the bundle includes the deps.
