### PR TITLE
SSL mode usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,31 @@ client = Etcd.client(host: '127.0.0.1', port: 4003)
 client = Etcd.client(:user_name => 'test', :password => 'pwd') # populates the authentication header for basic HTTP auth with user name and password (useful for proxied connections)
 client = Etcd.client(host: '127.0.0.1', port: 4003, allow_redirect: false) # wont let you run sensitive commands on non-leader machines, default is true
 ```
+
+### Create a client object to connect to a SSL etcd instance
+
+See [Etcd config](https://github.com/coreos/etcd/blob/master/Documentation/configuration.md) to setup `etcd` in SSL mode.
+
+Assuming you have these:
+* `myca.crt` - Your internal CAs certificate
+* `my-cert.crt` - The "client" cert
+* `my-cert.key` - The key corresponding to `my-cert.crt`
+
+If you were using self signed Certs and have your own CA, You would have set `-ca-file` in your etcd config also to use `myca.crt`.
+
+```ruby
+client=Etcd.client(
+  :host => "your-etcd-host",
+  :port => 443,
+  :use_ssl => true,
+  :ca_file => "/pathto/myca.crt",
+  :ssl_cert => OpenSSL::X509::Certificate.new( File.read("/pathto/my-cert.crt") ),
+  :ssl_key => OpenSSL::PKey::RSA.new("/etc/ssl/my-cert.key",passphrase)
+)
+#Omit passphrase if not set on your key.
+```
+
+
 ### Set a key
 ```ruby
 client.set('/nodes/n1', value: 1)

--- a/lib/etcd/client.rb
+++ b/lib/etcd/client.rb
@@ -54,6 +54,11 @@ module Etcd
       @config.user_name = opts[:user_name] || nil
       @config.password = opts[:password] || nil
       @config.allow_redirect = opts.key?(:allow_redirect) ? opts[:allow_redirect] : true
+      @config.ca_file = opts.key?(:ca_file) ? opts[:ca_file] : nil
+      #Provide a OpenSSL X509 cert here and not the path. See README
+      @config.ssl_cert = opts.key?(:ssl_cert) ? opts[:ssl_cert] : nil
+      #Provide the key (content) and not just the filename here. 
+      @config.ssl_key = opts.key?(:ssl_key) ? opts[:ssl_key] : nil
       yield @config if block_given?
     end
     # rubocop:enable CyclomaticComplexity


### PR DESCRIPTION
Constructor sets ca_file, ssl_cert and ssl_key. Updated README with https usage example.
