### PR TITLE
187

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _yardoc
 coverage
 spec/reports
 tmp
+etcd-v*-linux-amd64.tar.gz
+etcd-v*-linux-amd64/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,9 @@ Encoding:
 
 LineLength:
   Max: 100
+
+# Enforce old-school for ruby 1.8.7 (el6).
+#
+Style/HashSyntax:
+  Enabled: true
+  EnforcedStyle: hash_rockets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,9 @@
 AllCops:
-  Includes:
+  Include:
     - Gemfile
-    - lib/**
+    - lib/**/*
   Excludes:
-    - spec/**
+    - spec/**/*
 
 Encoding:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - bundle install --path .bundle
 
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in etcd.gemspec
 gemspec
 
-gem 'coco'
-gem 'rubocop'
 gem 'guard'
 gem 'guard-rake'
 gem 'json'

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Or install it yourself as:
     $ gem install etcd
 
 ## Usage
+
+:warning: Most of the examples below use the "new" hash syntax introduced
+in Ruby 1.9, but the library supports old-style hash syntax from 1.8.7
+as needed by some enterprise linux distros.
+
 ### Create a client object
 ```ruby
 client = Etcd.client # this will create a client against etcd server running on localhost on port 4001

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,14 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rdoc/task"
-require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new("spec")
 
-RuboCop::RakeTask.new do |task|
-  task.fail_on_error = true
+unless RUBY_VERSION < '1.9'
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new do |task|
+    task.fail_on_error = true
+  end
 end
 
 RDoc::Task.new do |rdoc|
@@ -17,7 +19,7 @@ end
 namespace :test do
   desc 'Run all of the quick tests.'
   task :quick do
-    Rake::Task['rubocop'].invoke
+    Rake::Task['rubocop'].invoke unless RUBY_VERSION < '1.9'
     Rake::Task['spec'].invoke
   end
 end

--- a/etcd.gemspec
+++ b/etcd.gemspec
@@ -18,7 +18,17 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  # Support enterprise distros, such as el6.
+  spec.required_ruby_version = ">= 1.8.7"
+
   spec.add_dependency "mixlib-log"
+
+  if RUBY_VERSION < "1.9"
+    spec.add_development_dependency "celluloid", "< 0.15"
+  else
+    spec.add_development_dependency "coco"
+    spec.add_development_dependency "rubocop"
+  end
 
   spec.add_development_dependency "uuid"
   spec.add_development_dependency "bundler"

--- a/lib/etcd/client.rb
+++ b/lib/etcd/client.rb
@@ -19,7 +19,6 @@ module Etcd
   #
   # rubocop:disable ClassLength
   class Client
-
     extend Forwardable
 
     HTTP_SUCCESS      = /^2/
@@ -35,7 +34,6 @@ module Etcd
     def_delegators :@config, :use_ssl, :verify_mode, :read_timeout
     def_delegators :@config, :user_name, :password, :allow_redirect
 
-
     attr_reader :host, :port, :http, :config
 
     ##
@@ -45,7 +43,7 @@ module Etcd
     # @opts [String] :host IP address of the etcd server (default 127.0.0.1)
     # @opts [Fixnum] :port Port number of the etcd server (default 4001)
     # @opts [Fixnum] :read_timeout set HTTP read timeouts (default 60)
-    # rubocop:disable CyclomaticComplexity
+    # rubocop:disable CyclomaticComplexity,MethodLength,PerceivedComplexity
     def initialize(opts = {})
       @host = opts[:host] || '127.0.0.1'
       @port = opts[:port] || 4001
@@ -58,13 +56,13 @@ module Etcd
       @config.password = opts[:password] || nil
       @config.allow_redirect = opts.key?(:allow_redirect) ? opts[:allow_redirect] : true
       @config.ca_file = opts.key?(:ca_file) ? opts[:ca_file] : nil
-      #Provide a OpenSSL X509 cert here and not the path. See README
+      # Provide a OpenSSL X509 cert here and not the path. See README
       @config.ssl_cert = opts.key?(:ssl_cert) ? opts[:ssl_cert] : nil
-      #Provide the key (content) and not just the filename here. 
+      # Provide the key (content) and not just the filename here.
       @config.ssl_key = opts.key?(:ssl_key) ? opts[:ssl_key] : nil
       yield @config if block_given?
     end
-    # rubocop:enable CyclomaticComplexity
+    # rubocop:enable CyclomaticComplexity,MethodLength,PerceivedComplexity
 
     # Returns the etcd api version that will be used for across API methods
     def version_prefix
@@ -118,6 +116,7 @@ module Etcd
       process_http_request(res, req, params)
     end
 
+    # rubocop:disable Style/GuardClause
     def setup_https(http)
       http.use_ssl = use_ssl
       http.verify_mode = verify_mode
@@ -134,6 +133,7 @@ module Etcd
         http.ca_file = config.ca_file
       end
     end
+    # rubocop:enable Style/GuardClause
 
     # need to ahve original request to process the response when it redirects
     def process_http_request(res, req = nil, params = nil)
@@ -175,4 +175,5 @@ module Etcd
       req
     end
   end
+  # rubocop:enable ClassLength
 end

--- a/lib/etcd/compat187.rb
+++ b/lib/etcd/compat187.rb
@@ -1,0 +1,30 @@
+# Encoding: utf-8
+
+require 'net/http'
+
+unless ::URI.respond_to?(:encode_www_form)
+  # Monkey-patch Ruby 1.8.7 to minimize impact on etcd-ruby codebase.
+  module URI
+    # rubocop:disable MethodLength
+    def self.encode_www_form(enum)
+      enum.map do |k, v|
+        if v.nil?
+          encode(k.to_s)
+        elsif v.respond_to?(:to_ary)
+          v.to_ary.map do |w|
+            str = encode(k.to_s)
+            unless w.nil?
+              str << '='
+              str << encode(w.to_s)
+            end
+          end.join('&')
+        else
+          str = encode(k.to_s)
+          str << '='
+          str << encode(v.to_s)
+        end
+      end.join('&')
+    end
+    # rubocop:enable MethodLength
+  end
+end

--- a/lib/etcd/keys.rb
+++ b/lib/etcd/keys.rb
@@ -69,6 +69,8 @@ module Etcd
     # @options [Hash] additional options for watching a key
     # @options [Fixnum] :index watch the specified key from given index
     # @options [Fixnum] :timeout specify http timeout
+    #
+    # rubocop:disable CyclomaticComplexity
     def watch(key, opts = {})
       params = { :wait => true }
       fail ArgumentError, 'Second argument must be a hash' unless opts.is_a?(Hash)
@@ -82,6 +84,7 @@ module Etcd
                              :timeout => timeout, :params => params)
       Response.from_http_response(response)
     end
+    # rubocop:enable CyclomaticComplexity
 
     def create_in_order(dir, opts = {})
       path  = key_endpoint + dir

--- a/lib/etcd/keys.rb
+++ b/lib/etcd/keys.rb
@@ -19,7 +19,7 @@ module Etcd
     # This method takes the following parameters as arguments
     # * key - whose data is to be retrieved
     def get(key, opts = {})
-      response = api_execute(key_endpoint + key, :get, params: opts)
+      response = api_execute(key_endpoint + key, :get, :params => opts)
       Response.from_http_response(response)
     end
 
@@ -36,7 +36,7 @@ module Etcd
       [:ttl, :value, :dir, :prevExist, :prevValue, :prevIndex].each do |k|
         payload[k] = opts[k] if opts.key?(k)
       end
-      response = api_execute(path, :put, params: payload)
+      response = api_execute(path, :put, :params => payload)
       Response.from_http_response(response)
     end
 
@@ -45,7 +45,7 @@ module Etcd
     # This method takes the following parameters as arguments
     # * key - key to be deleted
     def delete(key, opts = {})
-      response = api_execute(key_endpoint + key, :delete, params: opts)
+      response = api_execute(key_endpoint + key, :delete, :params => opts)
       Response.from_http_response(response)
     end
 
@@ -70,7 +70,7 @@ module Etcd
     # @options [Fixnum] :index watch the specified key from given index
     # @options [Fixnum] :timeout specify http timeout
     def watch(key, opts = {})
-      params = { wait: true }
+      params = { :wait => true }
       fail ArgumentError, 'Second argument must be a hash' unless opts.is_a?(Hash)
       timeout = opts[:timeout] || @read_timeout
       index = opts[:waitIndex] || opts[:index]
@@ -79,7 +79,7 @@ module Etcd
       params[:recursive] = opts[:recursive] if opts.key?(:recursive)
 
       response = api_execute(key_endpoint + key, :get,
-                             timeout: timeout, params: params)
+                             :timeout => timeout, :params => params)
       Response.from_http_response(response)
     end
 
@@ -90,7 +90,7 @@ module Etcd
       [:ttl, :value].each do |k|
         payload[k] = opts[k] if opts.key?(k)
       end
-      response = api_execute(path, :post, params: payload)
+      response = api_execute(path, :post, :params => payload)
       Response.from_http_response(response)
     end
 
@@ -104,11 +104,11 @@ module Etcd
     end
 
     def create(key, opts = {})
-      set(key, opts.merge(prevExist: false))
+      set(key, opts.merge(:prevExist => false))
     end
 
     def update(key, opts = {})
-      set(key, opts.merge(prevExist: true))
+      set(key, opts.merge(:prevExist => true))
     end
 
     def eternal_watch(key, index = nil)

--- a/lib/etcd/mod/leader.rb
+++ b/lib/etcd/mod/leader.rb
@@ -12,7 +12,7 @@ module Etcd
 
       def set_leader(key, value, ttl)
         path = mod_leader_endpoint + "#{key}?ttl=#{ttl}"
-        api_execute(path, :put, params: { name: value }).body
+        api_execute(path, :put, :params => { :name => value }).body
       end
 
       def get_leader(key)
@@ -20,7 +20,7 @@ module Etcd
       end
 
       def delete_leader(key, value)
-        path = mod_leader_endpoint + key + '?' + URI.encode_www_form(name: value)
+        path = mod_leader_endpoint + key + '?' + URI.encode_www_form(:name => value)
         api_execute(path, :delete).body
       end
     end

--- a/lib/etcd/mod/lock.rb
+++ b/lib/etcd/mod/lock.rb
@@ -14,7 +14,7 @@ module Etcd
         path = mod_lock_endpoint + key + "?ttl=#{ttl}"
         timeout = opts[:timeout] || 60
         Timeout.timeout(timeout) do
-          return api_execute(path, :post, params: opts).body
+          return api_execute(path, :post, :params => opts).body
         end
       end
 
@@ -25,19 +25,19 @@ module Etcd
         path = mod_lock_endpoint + key + "?ttl=#{ttl}"
         timeout = opts[:timeout] || 60
         Timeout.timeout(timeout) do
-          api_execute(path, :put, params: opts).body
+          api_execute(path, :put, :params => opts).body
         end
       end
 
       def get_lock(key, opts = {})
-        api_execute(mod_lock_endpoint + key, :get, params: opts).body
+        api_execute(mod_lock_endpoint + key, :get, :params => opts).body
       end
 
       def delete_lock(key, opts = {})
         unless opts.key?(:index) || opts.key?(:value)
           fail ArgumentError, 'You must pass index or value'
         end
-        api_execute(mod_lock_endpoint + key, :delete, params: opts)
+        api_execute(mod_lock_endpoint + key, :delete, :params => opts)
       end
 
       # rubocop:disable RescueException
@@ -49,7 +49,7 @@ module Etcd
         rescue Exception => e
           raise e
         ensure
-          delete_lock(key, index: lock_index)
+          delete_lock(key, :index => lock_index)
         end
       end
       # rubocop:enable RescueException

--- a/lib/etcd/mod/lock.rb
+++ b/lib/etcd/mod/lock.rb
@@ -42,7 +42,7 @@ module Etcd
 
       # rubocop:disable RescueException
       def lock(key, ttl, opts = {})
-        key = "/" + key unless key.start_with? '/'
+        key = '/' + key unless key.start_with? '/'
         lock_index = acquire_lock(key, ttl, opts)
         begin
           yield key

--- a/lib/etcd/node.rb
+++ b/lib/etcd/node.rb
@@ -9,7 +9,7 @@ module Etcd
     alias_method :createdIndex, :created_index
     alias_method :modifiedIndex, :modified_index
 
-    # rubocop:disable MethodLength
+    # rubocop:disable MethodLength,Style/GuardClause
     def initialize(opts = {})
       @created_index = opts['createdIndex']
       @modified_index = opts['modifiedIndex']
@@ -19,12 +19,13 @@ module Etcd
       @expiration = opts['expiration']
       @dir = opts['dir']
 
-      if opts['dir'] && (!!opts['nodes'])
+      if opts['dir'] && (!opts['nodes'].nil?)
         opts['nodes'].each do |data|
           children << Node.new(data)
         end
       end
     end
+    # rubocop:enable MethodLength,Style/GuardClause
 
     def <=>(other)
       key <=> other.key
@@ -39,7 +40,7 @@ module Etcd
     end
 
     def directory?
-      !! @dir
+      !@dir.nil?
     end
   end
 end

--- a/spec/etcd/basic_auth_client_spec.rb
+++ b/spec/etcd/basic_auth_client_spec.rb
@@ -27,7 +27,7 @@ describe 'Etcd basic auth client' do
   end
 
   it 'should set basic auth' do
-    Net::HTTPRequest.any_instance.should_receive(:basic_auth).with('test', 'pwd')
+    expect_any_instance_of(Net::HTTPRequest).to receive(:basic_auth).with('test', 'pwd')
     key = random_key
     value = uuid.generate
     client.set(key, :value => value)

--- a/spec/etcd/basic_auth_client_spec.rb
+++ b/spec/etcd/basic_auth_client_spec.rb
@@ -12,7 +12,7 @@ describe 'Etcd basic auth client' do
   end
 
   let(:client) do
-    Etcd.client(host: 'localhost') do |config|
+    Etcd.client(:host => 'localhost') do |config|
       config.user_name = 'test'
       config.password = 'pwd'
     end
@@ -30,7 +30,7 @@ describe 'Etcd basic auth client' do
     Net::HTTPRequest.any_instance.should_receive(:basic_auth).with('test', 'pwd')
     key = random_key
     value = uuid.generate
-    client.set(key, value: value)
+    client.set(key, :value => value)
     sleep 1
     expect(read_only_client.get(key).value).to eq(value)
   end

--- a/spec/etcd/client_spec.rb
+++ b/spec/etcd/client_spec.rb
@@ -40,7 +40,7 @@ describe Etcd::Client do
     it 'should redirect api request when allow_redirect is set' do
       key = random_key
       value = uuid.generate
-      resp = client.set(key, value: value)
+      resp = client.set(key, :value => value)
       resp.node.key.should eql key
       resp.node.value.should eql value
       client.get(key).value.should eql resp.value
@@ -51,7 +51,7 @@ describe Etcd::Client do
     before(:all) do
       key = random_key
       value = uuid.generate
-      @response = etcd_client.set(key, value: value)
+      @response = etcd_client.set(key, :value => value)
     end
 
     it '#etcd_index' do

--- a/spec/etcd/keys_spec.rb
+++ b/spec/etcd/keys_spec.rb
@@ -7,14 +7,14 @@ describe Etcd::Keys do
     it '#set/#get' do
       key = random_key
       value = uuid.generate
-      client.set(key, value: value)
+      client.set(key, :value => value)
       expect(client.get(key).value).to eq(value)
     end
 
     context '#exists?' do
       it 'should be true for existing keys' do
         key = random_key
-        client.create(key, value: 10)
+        client.create(key, :value => 10)
         expect(client.exists?(key)).to be(true)
       end
       it 'should be true for existing keys' do
@@ -25,21 +25,21 @@ describe Etcd::Keys do
     context 'directory' do
       it 'should be able to create a directory' do
         d = random_key
-        client.create(d, dir: true)
+        client.create(d, :dir => true)
         expect(client.get(d)).to be_directory
       end
       context 'empty' do
         it 'should be able to delete with dir flag' do
           d = random_key
-          client.create(d, dir: true)
-          client.delete(d, dir: true)
+          client.create(d, :dir => true)
+          client.delete(d, :dir => true)
           expect(client.exist?(d)).to be(false)
         end
 
         it 'should not be able to delete without dir flag' do
           d = random_key
-          client.create(d, dir: true)
-          client.create("#{d}/foobar", value: 10)
+          client.create(d, :dir => true)
+          client.create("#{d}/foobar", :value => 10)
           expect do
             client.delete(d)
           end.to raise_error(Etcd::NotFile)
@@ -48,18 +48,18 @@ describe Etcd::Keys do
       context 'not empty' do
         it 'should be able to delete with recursive flag' do
           d = random_key
-          client.create(d, dir: true)
+          client.create(d, :dir => true)
           client.create("#{d}/foobar")
           expect do
-            client.delete(d, dir: true, recursive: true)
+            client.delete(d, :dir => true, :recursive => true)
           end.to_not raise_error
         end
         it 'should be not able to delete without recursive flag' do
           d = random_key
-          client.create(d, dir: true)
+          client.create(d, :dir => true)
           client.create("#{d}/foobar")
           expect do
-            client.delete(d, dir: true)
+            client.delete(d, :dir => true)
           end.to raise_error(Etcd::DirNotEmpty)
         end
       end
@@ -81,7 +81,7 @@ describe Etcd::Keys do
 
   context 'with ssl' do
     before(:all) do
-      start_daemon(1, use_ssl: true)
+      start_daemon(1, :use_ssl => true)
     end
     after(:all) do
       stop_daemon
@@ -94,7 +94,7 @@ describe Etcd::Keys do
 
   context 'with ssl and client certificate' do
     before(:all) do
-      start_daemon(1, use_ssl: true, check_client_cert: true )
+      start_daemon(1, :use_ssl => true, :check_client_cert => true )
     end
     after(:all) do
       stop_daemon

--- a/spec/etcd/node_spec.rb
+++ b/spec/etcd/node_spec.rb
@@ -18,7 +18,7 @@ describe Etcd::Node do
     parent = random_key
     child = random_key
     value = uuid.generate
-    client.set(parent + child, value: value)
+    client.set(parent + child, :value => value)
     expect(client.get(parent + child)).to_not be_directory
     expect(client.get(parent)).to be_directory
   end
@@ -26,7 +26,7 @@ describe Etcd::Node do
   context '#children' do
     it 'should raise exception when invoked against a leaf node' do
       parent = random_key
-      client.create(random_key, value: 10)
+      client.create(random_key, :value => 10)
       expect do
         client.get(random_key).children
       end.to raise_error

--- a/spec/etcd/read_only_client_spec.rb
+++ b/spec/etcd/read_only_client_spec.rb
@@ -18,14 +18,14 @@ describe 'Etcd read only client' do
   it 'should not allow write' do
     key = random_key
     expect do
-      read_only_client.set(key, value: uuid.generate)
+      read_only_client.set(key, :value => uuid.generate)
     end.to raise_error(Net::HTTPRetriableError)
   end
 
   it 'should allow reads' do
     key = random_key
     value = uuid.generate
-    client.set(key, value: value)
+    client.set(key, :value => value)
     sleep 1
     expect(read_only_client.get(key).value).to eq(value)
   end
@@ -33,7 +33,7 @@ describe 'Etcd read only client' do
   it 'should allow watch' do
     key = random_key
     value = uuid.generate
-    index = client.set(key, value: value).node.modified_index
-    expect(read_only_client.watch(key, index: index).value).to eq(value)
+    index = client.set(key, :value => value).node.modified_index
+    expect(read_only_client.watch(key, :index => index).value).to eq(value)
   end
 end

--- a/spec/etcd/readme_spec.rb
+++ b/spec/etcd/readme_spec.rb
@@ -63,7 +63,7 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'set a key named "/message"' do
 
     before(:all) do
-      @response = etcd_client.set('/message', value: 'PinkFloyd')
+      @response = etcd_client.set('/message', :value => 'PinkFloyd')
     end
 
     it_should_behave_like 'response with valid http headers'
@@ -77,7 +77,7 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'get a key named "/message"' do
 
     before(:all) do
-      etcd_client.set('/message', value: 'PinkFloyd')
+      etcd_client.set('/message', :value => 'PinkFloyd')
       @response = etcd_client.get('/message')
     end
 
@@ -92,8 +92,8 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'change the value of a key named "/message"' do
 
     before(:all) do
-      etcd_client.set('/message', value: 'World')
-      @response = etcd_client.set('/message', value: 'PinkFloyd')
+      etcd_client.set('/message', :value => 'World')
+      @response = etcd_client.set('/message', :value => 'PinkFloyd')
     end
 
     it_should_behave_like 'response with valid http headers'
@@ -107,8 +107,8 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'delete a key named "/message"' do
 
     before(:all) do
-      etcd_client.set('/message', value: 'World')
-      etcd_client.set('/message', value: 'PinkFloyd')
+      etcd_client.set('/message', :value => 'World')
+      etcd_client.set('/message', :value => 'PinkFloyd')
       @response = etcd_client.delete('/message')
     end
 
@@ -123,9 +123,9 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'using ttl a key named "/message"' do
 
     before(:all) do
-      etcd_client.set('/message', value: 'World')
+      etcd_client.set('/message', :value => 'World')
       @set_time = Time.now
-      @response = etcd_client.set('/message', value: 'PinkFloyd', ttl: 5)
+      @response = etcd_client.set('/message', :value => 'PinkFloyd', :ttl => 5)
     end
 
     it_should_behave_like 'response with valid http headers'
@@ -155,12 +155,12 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'waiting for a change against a key named "/message"' do
 
     before(:all) do
-      etcd_client.set('/message', value: 'foo')
+      etcd_client.set('/message', :value => 'foo')
       thr = Thread.new do
         @response = etcd_client.watch('/message')
       end
       sleep 1
-      etcd_client.set('/message', value: 'PinkFloyd')
+      etcd_client.set('/message', :value => 'PinkFloyd')
       thr.join
     end
 
@@ -172,8 +172,8 @@ describe 'Etcd specs for the main etcd README examples' do
     end
 
     it 'should get the exact value by specifying a waitIndex' do
-      client.set('/message', value: 'someshit')
-      w_response = client.watch('/message', index: @response.node.modified_index)
+      client.set('/message', :value => 'someshit')
+      w_response = client.watch('/message', :index => @response.node.modified_index)
       expect(w_response.node.value).to eq('PinkFloyd')
     end
   end
@@ -181,7 +181,7 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'atomic in-order keys' do
 
     before(:all) do
-      @response = etcd_client.create_in_order('/queue', value: 'PinkFloyd')
+      @response = etcd_client.create_in_order('/queue', :value => 'PinkFloyd')
     end
 
     it_should_behave_like 'response with valid http headers'
@@ -196,8 +196,8 @@ describe 'Etcd specs for the main etcd README examples' do
     end
 
     it 'should have the child keys as monotonically increasing' do
-      first_response = client.create_in_order('/queue', value: 'The Jimi Hendrix Experience')
-      second_response = client.create_in_order('/queue', value: 'The Doors')
+      first_response = client.create_in_order('/queue', :value => 'The Jimi Hendrix Experience')
+      second_response = client.create_in_order('/queue', :value => 'The Doors')
       first_key = first_response.key.split('/').last.to_i
       second_key = second_response.key.split('/').last.to_i
       expect(first_key).to be < second_key
@@ -206,9 +206,9 @@ describe 'Etcd specs for the main etcd README examples' do
     it 'should enlist all children in sorted manner' do
       responses = []
       10.times do |n|
-        responses << client.create_in_order('/queue', value: 'Deep Purple - Track #{n}')
+        responses << client.create_in_order('/queue', :value => 'Deep Purple - Track #{n}')
       end
-      directory = client.get('/queue', sorted: true)
+      directory = client.get('/queue', :sorted => true)
       past_index = directory.children.index(responses.first.node)
       9.times do |n|
         current_index = directory.children.index(responses[n + 1].node)
@@ -221,7 +221,7 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'directory with ttl' do
 
     before(:all) do
-      @response = etcd_client.set('/directory', dir: true, ttl: 4)
+      @response = etcd_client.set('/directory', :dir => true, :ttl => 4)
     end
 
     it 'should create a directory' do
@@ -238,19 +238,19 @@ describe 'Etcd specs for the main etcd README examples' do
 
     it 'will throw error if updated without setting prevExist' do
       expect do
-        client.set('/directory', dir: true, ttl: 5)
+        client.set('/directory', :dir => true, :ttl => 5)
       end.to raise_error
     end
 
     it 'can be updated by setting  prevExist to true' do
-      client.set('/directory', prevExist: true, dir: true, ttl: 5)
+      client.set('/directory', :prevExist => true, :dir => true, :ttl => 5)
       expect(client.get('/directory').node.ttl).to eq(5)
     end
 
     it 'watchers should get expriy notification' do
-      client.set('/directory/a', value: 'Test')
-      client.set('/directory', prevExist: true, dir: true, ttl: 2)
-      response = client.watch('/directory/a', consistent: true, timeout: 3)
+      client.set('/directory/a', :value => 'Test')
+      client.set('/directory', :prevExist => true, :dir => true, :ttl => 2)
+      response = client.watch('/directory/a', :consistent => true, :timeout => 3)
       expect(response.action).to eq('expire')
     end
     it 'should be expired after ttl' do
@@ -264,53 +264,53 @@ describe 'Etcd specs for the main etcd README examples' do
   context 'atomic compare and swap' do
 
     it 'should  raise error if prevExist is passed a false' do
-      client.set('/foo', value: 'one')
+      client.set('/foo', :value => 'one')
       expect do
-        client.set('/foo', value: 'three',  prevExist: false)
+        client.set('/foo', :value => 'three',  :prevExist => false)
       end.to raise_error
     end
 
     it 'should raise error is prevValue is wrong' do
-      client.set('/foo', value: 'one')
+      client.set('/foo', :value => 'one')
       expect do
-        client.set('/foo', value: 'three', prevValue: 'two')
+        client.set('/foo', :value => 'three', :prevValue => 'two')
       end.to raise_error
     end
 
     it 'should allow setting the value when prevValue is right' do
-      client.set('/foo', value: 'one')
-      expect(client.set('/foo', value: 'three', prevValue: 'one').value).to eq('three')
+      client.set('/foo', :value => 'one')
+      expect(client.set('/foo', :value => 'three', :prevValue => 'one').value).to eq('three')
     end
   end
   context 'directory manipulation' do
     it 'should allow creating directory' do
-      expect(client.set('/dir', dir: true)).to be_directory
+      expect(client.set('/dir', :dir => true)).to be_directory
     end
 
     it 'should allow listing directory' do
-      client.set('/foo_dir/foo', value: 'bar')
+      client.set('/foo_dir/foo', :value => 'bar')
       expect(client.get('/').children.map(&:key)).to include('/foo_dir')
     end
 
     it 'should allow recursive directory listing' do
-      response = client.get('/', recursive: true)
+      response = client.get('/', :recursive => true)
       expect(response.children.find { |n|n.key == '/foo_dir' }.children).to_not be_empty
     end
 
     it 'should be able to delete empty directory without the recusrive flag' do
-      expect(client.delete('/dir', dir: true).action).to eq('delete')
+      expect(client.delete('/dir', :dir => true).action).to eq('delete')
     end
 
     it 'should be able to delete directory with children with the recusrive flag' do
-      expect(client.delete('/foo_dir', recursive: true).action).to eq('delete')
+      expect(client.delete('/foo_dir', :recursive => true).action).to eq('delete')
     end
   end
 
   context 'hidden nodes' do
 
     before(:all) do
-      etcd_client.set('/_message', value: 'Hello Hidden World')
-      etcd_client.set('/message', value: 'Hello World')
+      etcd_client.set('/_message', :value => 'Hello Hidden World')
+      etcd_client.set('/message', :value => 'Hello World')
     end
 
     it 'should not be visible in directory listing' do

--- a/spec/etcd/test_and_set_spec.rb
+++ b/spec/etcd/test_and_set_spec.rb
@@ -20,27 +20,27 @@ describe 'Etcd test_and_set' do
     key = random_key(2)
     old_value = uuid.generate
     new_value = uuid.generate
-    resp = client.set(key, value: old_value)
+    resp = client.set(key, :value => old_value)
     resp.node.value.should eql old_value
-    client.test_and_set(key, value: new_value, prevValue: old_value)
+    client.test_and_set(key, :value => new_value, :prevValue => old_value)
     expect(client.get(key).value).to eq(new_value)
   end
 
   it 'should fail when prev value is incorrect' do
     key = random_key(2)
     value = uuid.generate
-    client.set(key, value: value)
-    expect { client.test_and_set(key, value: 10, prevValue: 2) }.to raise_error(Etcd::TestFailed)
+    client.set(key, :value => value)
+    expect { client.test_and_set(key, :value => 10, :prevValue => 2) }.to raise_error(Etcd::TestFailed)
   end
 
   it '#create should succeed when the key is absent and update should fail' do
     key = random_key(2)
     value = uuid.generate
     expect do
-      client.update(key, value: value)
+      client.update(key, :value => value)
     end.to raise_error
     expect do
-      client.create(key, value: value)
+      client.create(key, :value => value)
     end.to_not raise_error
     expect(client.get(key).value).to eq(value)
   end
@@ -48,14 +48,14 @@ describe 'Etcd test_and_set' do
   it '#create should fail when the key is present and update should succeed' do
     key = random_key(2)
     value = uuid.generate
-    client.set(key, value: 1)
+    client.set(key, :value => 1)
 
     expect do
-      client.create(key, value: value)
+      client.create(key, :value => value)
     end.to raise_error
 
     expect do
-      client.update(key, value: value)
+      client.update(key, :value => value)
     end.to_not raise_error
   end
 end

--- a/spec/etcd/watch_spec.rb
+++ b/spec/etcd/watch_spec.rb
@@ -21,11 +21,11 @@ describe 'Etcd watch' do
     value1 = uuid.generate
     value2 = uuid.generate
 
-    index1 = client.create(key, value: value1).node.modifiedIndex
-    index2 = client.test_and_set(key, value: value2, prevValue: value1).node.modifiedIndex
+    index1 = client.create(key, :value => value1).node.modifiedIndex
+    index2 = client.test_and_set(key, :value => value2, :prevValue => value1).node.modifiedIndex
 
-    expect(client.watch(key, index: index1).node.value).to eq(value1)
-    expect(client.watch(key, index: index2).node.value).to eq(value2)
+    expect(client.watch(key, :index => index1).node.value).to eq(value1)
+    expect(client.watch(key, :index => index2).node.value).to eq(value2)
   end
 
   it 'with index, waits and return when the key is updated' do
@@ -36,7 +36,7 @@ describe 'Etcd watch' do
       response = client.watch(key)
     end
     sleep 2
-    client.set(key, value: value)
+    client.set(key, :value => value)
     thr.join
     expect(response.node.value).to eq(value)
   end
@@ -46,12 +46,12 @@ describe 'Etcd watch' do
     response = nil
     key = random_key
     value = uuid.generate
-    client.set("#{key}/subkey", value:"initial_value")
+    client.set("#{key}/subkey", :value => "initial_value")
     thr = Thread.new do
-      response = client.watch(key, recursive:true, timeout:3)
+      response = client.watch(key, :recursive => true, :timeout => 3)
     end
     sleep 2
-    client.set("#{key}/subkey", value: value)
+    client.set("#{key}/subkey", :value => value)
     thr.join
     expect(response.node.value).to eq(value)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,4 +134,10 @@ end
 
 RSpec.configure do |c|
   c.include Etcd::SpecHelper
+
+  # Allow both "should" and "expect" syntax.
+  # https://www.relishapp.com/rspec/rspec-expectations/docs/syntax-configuration
+  c.expect_with :rspec do |e|
+    e.syntax = [:should, :expect]
+  end
 end


### PR DESCRIPTION
Use case:

I'd like to use https://github.com/garethr/hiera-etcd (which depends on this gem)
to provide an etcd backend for hiera on my puppetmaster.
But I must use RHEL 6.5, which only ships with ruby 1.8.7.

I'm aware of Software Collections on RHEL 6, but PuppetLabs
doesn't yet support software collections.
https://tickets.puppetlabs.com/browse/PUP-1112

I'd deploy puppetmaster on RHEL 7 (Ruby 2.x), but el7
doesn't have the passenger gem available yet in rpm format.

Changes:
- Enforce ruby 1.8.7 hashrocket style and update via:
  `bundle exec rubocop --only='Style/HashSyntax' -a`
- Handle differences in net/http codebase between 1.8 and 1.9+
- On ruby 1.8, use ~~posix-spawn~~ popen in test harness
  
  > The posix-spawn library aims to implement a subset of the Ruby
  > 1.9 Process::spawn interface in a way that takes advantage of
  > fast process spawning interfaces when available and provides
  > sane fallbacks on systems that do not.
- Exclude rubocop and coco in bundle on ruby 1.8 to
  avoid pulling in deps like celluloid and rainbow.
