### PR TITLE
Fix naming conflict with StandardError

### DIFF
--- a/lib/etcd/exceptions.rb
+++ b/lib/etcd/exceptions.rb
@@ -6,11 +6,11 @@ require 'json'
 module Etcd
   # Represents all etcd custom errors
   class Error < StandardError
-    attr_reader :cause, :error_code, :index
+    attr_reader :caused_by, :error_code, :index
 
     def initialize(opts = {})
       super(opts['message'])
-      @cause = opts['cause']
+      @caused_by = opts['cause']
       @index = opts['index']
       @error_code = opts['errorCode']
     end
@@ -24,7 +24,7 @@ module Etcd
     end
 
     def inspect
-      "<#{self.class}: index:#{index}, code:#{error_code}, cause:'#{cause}'>"
+      "<#{self.class}: index:#{index}, code:#{error_code}, cause:'#{caused_by}'>"
     end
   end
 


### PR DESCRIPTION
Ruby standard Error have a builtin method from ruby 2.1 onwards which
returns the exception object which caused the current error
See: http://ruby-doc.org/core-2.3.1/Exception.html#method-i-cause

Using the same variable for storing the error cause string can side effects
as in #59 

Fixes #59 
