### PR TITLE
[ci skip] Removed mention of removed feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,6 @@ client.watch('/nodes/n1') # will wait till the key is changed, and return once i
 client.get('/nodes')
 ```
 
-### Get machines in the cluster
-```ruby
-client.machines
-```
-
 ### Get leader of the cluster
 ```ruby
 client.leader


### PR DESCRIPTION
Support for the method `machines` is removed in https://github.com/ranjib/etcd-ruby/commit/d5696988f5a377033728188a77bfd528dd148ad9 but Readme wasn't updated

Related #56