### PR TITLE
Eternal watch should be robust when blocks are slow

### DIFF
--- a/lib/etcd/keys.rb
+++ b/lib/etcd/keys.rb
@@ -115,9 +115,9 @@ module Etcd
       set(key, opts.merge(prevExist: true))
     end
 
-    def eternal_watch(key, index = nil)
+    def eternal_watch(key, opts = {})
       loop do
-        response = watch(key, index)
+        response = watch(key, opts)
         yield response
       end
     end

--- a/lib/etcd/keys.rb
+++ b/lib/etcd/keys.rb
@@ -116,9 +116,12 @@ module Etcd
     end
 
     def eternal_watch(key, opts = {})
+      next_index = opts[:waitIndex]
       loop do
+        opts = opts.merge(waitIndex: next_index) if next_index
         response = watch(key, opts)
         yield response
+        next_index = response.node.modified_index + 1
       end
     end
 

--- a/spec/etcd/watch_spec.rb
+++ b/spec/etcd/watch_spec.rb
@@ -31,7 +31,6 @@ describe 'Etcd watch' do
     expect(response.node.value).to eq(value)
   end
 
-
   it 'with recrusive, waits and return when the key is updated' do
     response = nil
     key = random_key


### PR DESCRIPTION
In order to ensure that we don't miss any key changes while we are doing work, the `eternal_watch` method should track the `modifiedIndex` attribute of the previous response and watch again using the next index value.

This pull request also adds specs for the other basic behaviours of `eternal_watch`, and fixes a minor but when it is called with only one argument.