### PR TITLE
Use faraday for requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ rvm:
   - 2.5.0
 branches:
   only:
-    - use_faraday
+    - master
 script: "ETCD_BIN=./etcd-v2.0.0-rc.1-linux-amd64/etcd bundle exec rake spec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ before_install:
   - bundle install
 
 rvm:
-  - 1.9.3
-  - 2.1.0
-  - 2.2.0
-  - 2.4.2
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
   - 2.5.0
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ rvm:
   - 2.2.0
 branches:
   only:
-    - master
+    - use_faraday
 script: "ETCD_BIN=./etcd-v2.0.0-rc.1-linux-amd64/etcd bundle exec rake spec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - 1.9.3
   - 2.1.0
   - 2.2.0
+  - 2.4.2
+  - 2.5.0
 branches:
   only:
     - use_faraday

--- a/etcd.gemspec
+++ b/etcd.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9'
 
   spec.add_dependency "mixlib-log"
+  spec.add_dependency "faraday"
   spec.add_development_dependency "uuid"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
As mentioned in #39, using [faraday](https://github.com/lostisland/faraday)  would be nice because middlewares could be used for custom retrying/loadbalancing strategies. This is a first go at using faraday to make requests. All of the existing tests still pass on latest supported verisons of ruby.
Not sure what the current maintenence situation is with this repository but hopefully this pr can be considered.